### PR TITLE
Update config key and metadata for email notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -855,7 +855,6 @@ For issues, feature requests, or questions about the EmailNotification extension
 - Create an issue in the repository
 - Consult the [Symfony Mailer documentation](https://symfony.com/doc/current/mailer.html)
 - Check the extension health monitoring for diagnostics
-- Review the migration guide for PHPMailer → Symfony Mailer issues
 
 ---
 

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
             "url": "${GLUEFUL_PATH}"
         }
     ],
-    "homepage": "https://github.com/glueful/extensions/tree/main/extensions/EmailNotification",
+    "homepage": "https://github.com/glueful/email-notification",
     "autoload": {
         "psr-4": {
             "Glueful\\Extensions\\EmailNotification\\": "src/"
@@ -62,7 +62,7 @@
             "publisher": "glueful-team",
             "provider": "Glueful\\Extensions\\EmailNotification\\EmailNotificationServiceProvider",
             "requires": {
-                "glueful": ">=1.5.0",
+                "glueful": ">=1.6.2",
                 "extensions": []
             }
         }

--- a/src/EmailFormatter.php
+++ b/src/EmailFormatter.php
@@ -65,7 +65,7 @@ class EmailFormatter
         $templateConfig = $mailConfig['templates'] ?? [];
 
         // Get extension configuration
-        $extensionConfig = \config('email-notification', []);
+        $extensionConfig = \config('emailnotification', []);
         $extensionTemplates = $extensionConfig['templates'] ?? [];
 
         // Set primary template path


### PR DESCRIPTION
Changed the config key from 'email-notification' to 'emailnotification' in EmailFormatter.php. Updated composer.json homepage URL and minimum glueful version requirement. Removed outdated migration guide reference from README.md.