### PR TITLE
Register extension metadata and bump version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
             "name": "EmailNotification",
             "displayName": "Email Notification",
             "description": "Provides email notification capabilities using Symfony Mailer",
-            "version": "1.1.0",
+            "version": "1.1.1",
             "icon": "assets/icon.png",
             "galleryBanner": {
                 "color": "#3064D0",
@@ -62,7 +62,7 @@
             "publisher": "glueful-team",
             "provider": "Glueful\\Extensions\\EmailNotification\\EmailNotificationServiceProvider",
             "requires": {
-                "glueful": ">=1.6.2",
+                "glueful": ">=1.7.1",
                 "extensions": []
             }
         }

--- a/src/EmailNotificationServiceProvider.php
+++ b/src/EmailNotificationServiceProvider.php
@@ -94,6 +94,19 @@ class EmailNotificationServiceProvider extends \Glueful\Extensions\ServiceProvid
                 }
             }
         }
+
+        // Register extension metadata for CLI and diagnostics
+        try {
+            $this->app->get(\Glueful\Extensions\ExtensionManager::class)->registerMeta(self::class, [
+                'slug' => 'email-notification',
+                'name' => 'EmailNotification',
+                'version' => '1.1.1',
+                'description' => 'Provides email notification capabilities using Symfony Mailer',
+            ]);
+        } catch (\Throwable $e) {
+            // Non-critical
+            error_log('[EmailNotification] Failed to register extension metadata: ' . $e->getMessage());
+        }
     }
 
     /**


### PR DESCRIPTION
Added registration of extension metadata for CLI and diagnostics in EmailNotificationServiceProvider. Updated composer.json to version 1.1.1 and set minimum glueful requirement to 1.7.1.