### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,15 +47,49 @@ php glueful extensions:list
 php glueful extensions:info EmailNotification
 ```
 
-### Development enable/disable (optional)
+### Enabling the extension
+
+There are two ways to enable this extension:
+
+1) Manual (recommended; works in all environments)
+
+Edit your project's `config/extensions.php` and add the provider class to the `enabled` list:
+
+```php
+// config/extensions.php
+return [
+    'enabled' => [
+        Glueful\Extensions\EmailNotification\EmailNotificationServiceProvider::class,
+        // other providers...
+    ],
+    // ...
+];
+```
+
+In production, build the cache for deterministic startup:
 
 ```bash
-# Enable the extension locally (updates config/extensions.php)
+php glueful extensions:cache
+```
+
+Verify discovery:
+
+```bash
+php glueful extensions:list
+php glueful extensions:info 'Glueful\\Extensions\\EmailNotification\\EmailNotificationServiceProvider'
+```
+
+2) Development helper (prints instructions)
+
+```bash
+# Dev-only helper: prints how to edit config/extensions.php
 php glueful extensions:enable EmailNotification
 
-# Disable locally
+# To disable, remove/comment the provider entry (or use):
 php glueful extensions:disable EmailNotification
 ```
+
+Note: The enable/disable commands do not modify files in production; always manage providers through `config/extensions.php` and deployment.
 
 ### Provider Bridge Installation
 

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
             "name": "EmailNotification",
             "displayName": "Email Notification",
             "description": "Provides email notification capabilities using Symfony Mailer",
-            "version": "1.1.1",
+            "version": "1.1.2",
             "icon": "assets/icon.png",
             "galleryBanner": {
                 "color": "#3064D0",

--- a/src/EmailNotificationServiceProvider.php
+++ b/src/EmailNotificationServiceProvider.php
@@ -100,7 +100,7 @@ class EmailNotificationServiceProvider extends \Glueful\Extensions\ServiceProvid
             $this->app->get(\Glueful\Extensions\ExtensionManager::class)->registerMeta(self::class, [
                 'slug' => 'email-notification',
                 'name' => 'EmailNotification',
-                'version' => '1.1.1',
+                'version' => '1.1.2',
                 'description' => 'Provides email notification capabilities using Symfony Mailer',
             ]);
         } catch (\Throwable $e) {


### PR DESCRIPTION
#
This pull request updates the Email Notification extension to version 1.1.2 and significantly improves the documentation for enabling the extension. The main focus is on making the enablement process clearer and more robust, especially distinguishing between development and production practices.

Documentation improvements:

* Expanded the "Enabling the extension" section in `README.md` to detail two methods: manual configuration via `config/extensions.php` (recommended for all environments), and a development helper command. It also clarifies that enable/disable commands do not modify files in production and emphasizes best practices for production deployment.

Version updates:

* Bumped the extension version from 1.1.1 to 1.1.2 in both `composer.json` and in the `EmailNotificationServiceProvider` registration metadata. [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L55-R55) [[2]](diffhunk://#diff-296847251853a5e9b7645d522e08afc8e51f154416bbf9f3c9aeaaf706f970f6L103-R103)