### PR TITLE
Update PHP and glueful version requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "keywords": ["notifications", "communication", "email", "smtp"],
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "vlucas/phpdotenv": "^5.6",
         "symfony/mailer": "^6.3 || ^7.0",
         "symfony/mime": "^6.3 || ^7.0"
@@ -62,7 +62,7 @@
             "publisher": "glueful-team",
             "provider": "Glueful\\Extensions\\EmailNotification\\EmailNotificationServiceProvider",
             "requires": {
-                "glueful": ">=1.7.1",
+                "glueful": ">=1.9.0",
                 "extensions": []
             }
         }


### PR DESCRIPTION
Bump PHP requirement to ^8.3 and glueful dependency to >=1.9.0 in composer.json to ensure compatibility with newer versions.