### PR TITLE
Bump version to 1.2.0 and update requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [1.2.0] - 2026-01-17
+
+### Breaking Changes
+- **PHP 8.3 Required**: Minimum PHP version raised from 8.2 to 8.3.
+- **Glueful 1.9.0 Required**: Minimum framework version raised to 1.9.0.
+
+### Changed
+- Updated `composer.json` PHP requirement to `^8.3`.
+- Updated `extra.glueful.requires.glueful` to `>=1.9.0`.
+
+### Notes
+- Ensure your environment runs PHP 8.3 or higher before upgrading.
+- Run `composer update` after upgrading.
+
 ## [1.0.0] - 2025-09-13
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
             "name": "EmailNotification",
             "displayName": "Email Notification",
             "description": "Provides email notification capabilities using Symfony Mailer",
-            "version": "1.1.2",
+            "version": "1.2.0",
             "icon": "assets/icon.png",
             "galleryBanner": {
                 "color": "#3064D0",


### PR DESCRIPTION
Raised minimum PHP version to 8.3 and Glueful framework requirement to 1.9.0. Updated composer.json and changelog to reflect these breaking changes.