### PR TITLE
Improve mail config merging and logo URL resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [1.2.1] - 2026-01-24
+
+### Changed
+- **EmailChannel**: Improved configuration loading to merge core mail settings from `services.mail` with extension-specific config.
+  - Core framework mail settings now take precedence for mail transport configuration.
+  - Allows centralized mail configuration in the main application while extension-specific settings remain customizable.
+- **EmailFormatter**: Updated logo URL resolution to use `global_variables` from config.
+  - Now reads from `services.mail.templates.global_variables.logo_url` for consistency with core framework.
+  - Falls back to extension default if not configured.
+
+### Notes
+- No breaking changes. Existing configurations continue to work.
+- For centralized mail configuration, define settings in `config/services.php` under the `mail` key.
+
 ## [1.2.0] - 2026-01-17
 
 ### Breaking Changes

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
             "name": "EmailNotification",
             "displayName": "Email Notification",
             "description": "Provides email notification capabilities using Symfony Mailer",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "icon": "assets/icon.png",
             "galleryBanner": {
                 "color": "#3064D0",

--- a/src/EmailChannel.php
+++ b/src/EmailChannel.php
@@ -46,9 +46,14 @@ class EmailChannel implements NotificationChannel
      */
     public function __construct(array $config = [], ?EmailFormatter $formatter = null)
     {
-        // Load default config if not provided
+        // Load config: merge core mail settings with extension-specific config
         if (empty($config)) {
-            $this->config = \config('email-notification') ?? [];
+            // Load core mail configuration from services.php
+            $coreMailConfig = \config('services.mail') ?? [];
+            // Load extension-specific configuration
+            $extensionConfig = \config('emailnotification') ?? [];
+            // Merge: core settings take precedence for mail transport
+            $this->config = array_merge($extensionConfig, $coreMailConfig);
         } else {
             $this->config = $config;
         }

--- a/src/EmailFormatter.php
+++ b/src/EmailFormatter.php
@@ -147,9 +147,13 @@ class EmailFormatter
         $templateData['subject'] = $result['subject'];
         $templateData['title'] = $result['subject']; // Add title as an alias to subject
 
-        // Ensure logo_url is always available, using config default if not provided
+        // Ensure logo_url is always available, using global_variables from config
+        // The global_variables are loaded from services.mail.templates.global_variables
         if (!isset($templateData['logo_url'])) {
-            $templateData['logo_url'] = \config('mail.logo_url', 'https://brand.glueful.com/logo.png');
+            $globalVars = $this->defaultOptions['global_variables'] ?? [];
+            $templateData['logo_url'] = $globalVars['logo_url']
+                ?? \config('services.mail.templates.global_variables.logo_url')
+                ?? 'https://brand.glueful.com/logo.png';
         }
 
         // Add notifiable information

--- a/src/EmailNotificationServiceProvider.php
+++ b/src/EmailNotificationServiceProvider.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Glueful\Extensions\EmailNotification;
 
-use Glueful\Logging\LogManager;
 use Glueful\Notifications\Services\ChannelManager;
 
 /**
@@ -27,7 +26,7 @@ class EmailNotificationServiceProvider extends \Glueful\Extensions\ServiceProvid
      */
     public function getVersion(): string
     {
-        return '1.0.0';
+        return '1.2.1';
     }
 
     /**


### PR DESCRIPTION
EmailChannel now merges core mail settings from services.mail with extension-specific config, giving precedence to core settings for mail transport. EmailFormatter resolves logo_url from services.mail.templates.global_variables for consistency, with fallback to extension default. Version bumped to 1.2.1.