### PR TITLE
Prefer custom templates; read version from composer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [1.4.0] - 2026-02-06
+
+### Changed
+- **EmailFormatter**: `applyLayout()` now searches `custom_paths` first, then falls back to the default templates path, consistent with partial and template resolution.
+- **EmailFormatter**: `includePartial()` now searches `custom_paths` first, then extension defaults.
+- **EmailFormatter**: `registerDefaultTemplates()` now loads built-in templates first, then overrides/extends from `custom_paths`.
+
+- **Version Management**: Version is now read from `composer.json` at runtime via `EmailNotificationServiceProvider::composerVersion()`.
+  - `getVersion()`, `registerMeta()`, and `NotivaProvider::getExtensionInfo()` all use `composerVersion()` instead of hardcoded strings.
+  - Config `extension_version` is injected dynamically in `register()` from `composer.json`.
+  - Future releases only require updating `composer.json` and `CHANGELOG.md`.
+
+### Notes
+- No breaking changes. Custom paths configured via `services.mail.templates.custom_paths` now consistently override built-in templates, partials, and layouts.
+
 ## [1.3.0] - 2026-01-31
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -562,6 +562,8 @@ Configure custom templates in `config/services.php`:
        └── footer.html
    ```
 
+> **Override behavior**: if you set `services.mail.templates.custom_paths`, the extension will load templates from those paths first. Only templates or partials you provide are overridden; everything else falls back to the built‑in templates.
+
 2. **Custom Template Example** (`resources/mail/invoice.html`):
    ```html
    <!DOCTYPE html>

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
             "name": "EmailNotification",
             "displayName": "Email Notification",
             "description": "Provides email notification capabilities using Symfony Mailer",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "icon": "assets/icon.png",
             "galleryBanner": {
                 "color": "#3064D0",

--- a/config/emailnotification.php
+++ b/config/emailnotification.php
@@ -27,7 +27,7 @@ return [
             'auto_text_version' => true,
         ],
         'extension_variables' => [
-            'extension_version' => '1.3.0',
+            'extension_version' => 'dev', // Overridden at runtime from composer.json
             'powered_by' => 'Glueful EmailNotification Extension',
         ],
     ],

--- a/src/EmailNotificationProvider.php
+++ b/src/EmailNotificationProvider.php
@@ -247,7 +247,7 @@ class EmailNotificationProvider implements NotificationExtension
     {
         return [
             'name' => 'Email Notification Channel',
-            'version' => '1.3.0',
+            'version' => EmailNotificationServiceProvider::composerVersion(),
             'description' => 'Provides email notification capabilities using Symfony Mailer',
             'author' => 'Glueful',
             'channels' => ['email'],


### PR DESCRIPTION
Email templates and version handling updated: EmailFormatter now searches configured custom_paths before falling back to built-in templates/partials/layouts and allows custom templates to override defaults (applyLayout, includePartial, registerDefaultTemplates). EmailNotificationServiceProvider adds a cached composerVersion() that reads version from composer.json at runtime and injects it into config/register/meta; getVersion() now uses this method. composer.json version bumped to 1.4.0, config default extension_version set to 'dev' (overridden at runtime). README and CHANGELOG updated to document the behavior and versioning change. No breaking changes—custom paths now consistently override built-in templates.