### PR TITLE
Bump to 1.5.0 and update Glueful exception import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [1.5.0] - 2026-02-09
+
+### Changed
+- **Framework Compatibility**: Updated minimum framework requirement to Glueful 1.30.0 (Diphda release)
+- **Exception Imports**: Migrated from deleted legacy bridge class to modern exception namespace
+  - `Glueful\Exceptions\BusinessLogicException` → `Glueful\Http\Exceptions\Domain\BusinessLogicException` in `EmailFormatter`
+- **composer.json**: Updated `extra.glueful.requires.glueful` to `>=1.30.0`, version bumped to `1.5.0`
+
+### Notes
+- No breaking changes to extension API. Import path change is internal.
+- Requires Glueful Framework 1.30.0+ due to removal of legacy exception bridge classes.
+
 ## [1.4.0] - 2026-02-06
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
             "name": "EmailNotification",
             "displayName": "Email Notification",
             "description": "Provides email notification capabilities using Symfony Mailer",
-            "version": "1.4.0",
+            "version": "1.5.0",
             "icon": "assets/icon.png",
             "galleryBanner": {
                 "color": "#3064D0",
@@ -64,7 +64,7 @@
             "publisher": "glueful-team",
             "provider": "Glueful\\Extensions\\EmailNotification\\EmailNotificationServiceProvider",
             "requires": {
-                "glueful": ">=1.22.0",
+                "glueful": ">=1.30.0",
                 "extensions": []
             }
         }

--- a/src/EmailFormatter.php
+++ b/src/EmailFormatter.php
@@ -6,7 +6,7 @@ namespace Glueful\Extensions\EmailNotification;
 
 use Glueful\Bootstrap\ApplicationContext;
 use Glueful\Notifications\Contracts\Notifiable;
-use Glueful\Exceptions\BusinessLogicException;
+use Glueful\Http\Exceptions\Domain\BusinessLogicException;
 
 /**
  * Email Formatter


### PR DESCRIPTION
Release 1.5.0: update composer metadata and adjust code to match Glueful 1.30.0 (Diphda) changes. composer.json: bump extension version to 1.5.0 and raise minimum Glueful requirement to >=1.30.0. src/EmailFormatter.php: replace deprecated Glueful\Exceptions\BusinessLogicException import with Glueful\Http\Exceptions\Domain\BusinessLogicException. CHANGELOG.md: add 1.5.0 entry documenting compatibility and import changes. This is an internal import/path update to remain compatible with Glueful 1.30.0; no extension API breaking changes.