### PR TITLE
Release 1.8.0 — migrate to framework 1.51.0 Notifications APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [1.8.0] - 2026-06-06 — Notification Subsystem Refinement (Framework 1.51)
+
+### Added
+
+- **Structured channel results.** `EmailChannel` now implements `Glueful\Notifications\Contracts\RichNotificationChannel` and returns a `NotificationResult` from `sendNotification()` — surfacing the Symfony provider message id, send latency, and stable error codes (`no_recipient` → non-retryable, `transport_exception` → retryable). The framework dispatcher (1.51.0+) records these per channel; the legacy `send(): bool` contract is preserved by delegating to `sendNotification()`.
+
+### Changed
+
+- **Minimum framework requirement raised to `glueful/framework >=1.51.0`** (`require-dev` pinned to `^1.51.0`).
+- **Channel/hook registration migrated to the framework's extension helpers.** `EmailNotificationServiceProvider::boot()` now calls `registerNotificationChannel()` / `registerNotificationExtension()` instead of reaching into the container by hand. This is now the **only** wiring path — framework 1.51.0 stopped hardcoding the `EmailNotification` provider in its notification jobs, so an extension that doesn't register from `boot()` won't auto-wire into the shared dispatcher used by async dispatch/retries.
+- **Retry config moved to the channel-agnostic key.** Framework 1.51.0 reads notification retry options from `notifications.retry` (was `emailnotification.retry`). The provider now merges its `retry` block under `notifications.retry` in `register()`, so existing `MAIL_RETRY_*` env tuning keeps working with no app change.
+
+### Fixed
+
+- **Extension version reporting.** `composerVersion()` read a non-existent top-level `version` key (returning `0.0.0` to the CLI/diagnostics); it now reads the canonical `extra.glueful.version`.
+
+### Notes
+
+- The active email-delivery path (formatting, transports, failover) is unchanged. The rich result is captured by sending through the configured transport directly (equivalent to the prior `Mailer::send()` path, which used no Messenger bus).
+
 ## [1.7.0] - 2026-06-05 — Framework 1.50 Compatibility
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "symfony/mime": "^6.3 || ^7.0"
     },
     "require-dev": {
-        "glueful/framework": "^1.50.1",
+        "glueful/framework": "^1.51.0",
         "phpunit/phpunit": "^10.5",
         "squizlabs/php_codesniffer": "^3.6",
         "phpstan/phpstan": "^1.0"
@@ -51,7 +51,7 @@
             "name": "EmailNotification",
             "displayName": "Email Notification",
             "description": "Provides email notification capabilities using Symfony Mailer",
-            "version": "1.7.0",
+            "version": "1.8.0",
             "icon": "assets/icon.png",
             "galleryBanner": {
                 "color": "#3064D0",
@@ -64,7 +64,7 @@
             "publisher": "glueful-team",
             "provider": "Glueful\\Extensions\\EmailNotification\\EmailNotificationServiceProvider",
             "requires": {
-                "glueful": ">=1.50.1",
+                "glueful": ">=1.51.0",
                 "extensions": []
             }
         }

--- a/src/EmailChannel.php
+++ b/src/EmailChannel.php
@@ -7,9 +7,10 @@ namespace Glueful\Extensions\EmailNotification;
 use Glueful\Bootstrap\ApplicationContext;
 use Glueful\Logging\LogManager;
 use Glueful\Notifications\Contracts\Notifiable;
-use Glueful\Notifications\Contracts\NotificationChannel;
-use Symfony\Component\Mailer\Mailer;
+use Glueful\Notifications\Contracts\RichNotificationChannel;
+use Glueful\Notifications\Results\NotificationResult;
 use Symfony\Component\Mailer\Transport;
+use Symfony\Component\Mailer\Transport\TransportInterface;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
@@ -20,9 +21,14 @@ use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
  * Implementation of the NotificationChannel interface for sending
  * notifications via email using Symfony Mailer.
  *
+ * Implements {@see RichNotificationChannel}, so the framework dispatcher (1.51.0+) records a
+ * structured {@see NotificationResult} per send — provider message id, error code/message,
+ * retryability, and latency. The legacy {@see self::send()} bool contract is preserved by
+ * delegating to {@see self::sendNotification()}.
+ *
  * @package Glueful\Extensions\EmailNotification
  */
-class EmailChannel implements NotificationChannel
+class EmailChannel implements RichNotificationChannel
 {
     /**
      * @var array Email configuration
@@ -78,7 +84,10 @@ class EmailChannel implements NotificationChannel
     }
 
     /**
-     * Send the notification to the specified notifiable entity
+     * Send the notification to the specified notifiable entity (legacy bool contract).
+     *
+     * Delegates to {@see self::sendNotification()} and collapses the structured result to a
+     * bool, so existing `NotificationChannel::send()` callers are unaffected.
      *
      * @param Notifiable $notifiable The entity receiving the notification
      * @param array $data Notification data including content and metadata
@@ -86,24 +95,52 @@ class EmailChannel implements NotificationChannel
      */
     public function send(Notifiable $notifiable, array $data): bool
     {
+        return $this->sendNotification($notifiable, $data)->success;
+    }
+
+    /**
+     * Send the notification and return a structured {@see NotificationResult}.
+     *
+     * Captures the Symfony provider message id (when the transport returns one) and the send
+     * latency, and maps failure modes to stable error codes: `no_recipient` (non-retryable) and
+     * `transport_exception` (retryable).
+     *
+     * @param Notifiable $notifiable The entity receiving the notification
+     * @param array $data Notification data including content and metadata
+     * @return NotificationResult Structured outcome of the delivery attempt
+     */
+    public function sendNotification(Notifiable $notifiable, array $data): NotificationResult
+    {
         // Get the recipient email address
         $recipientEmail = $notifiable->routeNotificationFor('email');
 
         if (empty($recipientEmail)) {
-            return false;
+            return NotificationResult::failure(
+                errorCode: 'no_recipient',
+                errorMessage: 'Notifiable has no email route address.',
+                retryable: false
+            );
         }
 
         // Format the notification data for email
         $emailData = $this->format($data, $notifiable);
+        $start = microtime(true);
 
         try {
-            $mailer = $this->createMailer();
+            $transport = $this->createTransport();
             $email = $this->createEmail($emailData, $recipientEmail);
 
-            // Send the email
-            $mailer->send($email);
-            return true;
+            // Send via the transport directly so we can surface the provider message id.
+            $sent = $transport->send($email);
+            $latencyMs = (int) round((microtime(true) - $start) * 1000);
+
+            return NotificationResult::success(
+                providerMessageId: $sent?->getMessageId(),
+                latencyMs: $latencyMs
+            );
         } catch (TransportExceptionInterface $e) {
+            $latencyMs = (int) round((microtime(true) - $start) * 1000);
+
             // Log the error using LogManager
             $this->logger->error('Email notification failed: ' . $e->getMessage(), [
                 'notifiable_id' => $notifiable->getNotifiableId(),
@@ -116,7 +153,12 @@ class EmailChannel implements NotificationChannel
                 ]
             ]);
 
-            return false;
+            return NotificationResult::failure(
+                errorCode: 'transport_exception',
+                errorMessage: $e->getMessage(),
+                retryable: true,
+                latencyMs: $latencyMs
+            );
         }
     }
 
@@ -199,12 +241,13 @@ class EmailChannel implements NotificationChannel
     }
 
     /**
-     * Create and configure a Symfony Mailer instance
+     * Build the configured Symfony transport (used directly by {@see self::sendNotification()}
+     * so the returned SentMessage's provider message id can be surfaced).
      *
-     * @return Mailer Configured mailer instance
-     * @throws \Exception If mailer cannot be configured
+     * @return TransportInterface Configured transport instance
+     * @throws \Exception If the mailer configuration is missing
      */
-    private function createMailer(): Mailer
+    private function createTransport(): TransportInterface
     {
         // Get the default mailer configuration
         $defaultMailer = $this->config['default'] ?? 'smtp';
@@ -223,8 +266,7 @@ class EmailChannel implements NotificationChannel
         // Validate configuration based on transport type
         if (!$isProviderBridge && empty($mailerConfig['host'])) {
             // Fallback to null transport for development environments
-            $transport = Transport::fromDsn('null://null');
-            return new Mailer($transport);
+            return Transport::fromDsn('null://null');
         }
 
         // For provider bridges, validate they have required credentials
@@ -233,8 +275,7 @@ class EmailChannel implements NotificationChannel
                              (!empty($mailerConfig['username']) && !empty($mailerConfig['password']));
             if (!$hasCredentials) {
                 // Fallback to null transport if credentials missing
-                $transport = Transport::fromDsn('null://null');
-                return new Mailer($transport);
+                return Transport::fromDsn('null://null');
             }
         }
 
@@ -245,13 +286,11 @@ class EmailChannel implements NotificationChannel
 
             if ($hasValidFailover) {
                 // Use failover transport if configured
-                $transport = \Glueful\Extensions\EmailNotification\TransportFactory::createFailover($this->config);
-            } else {
-                // Use the default transport with enhanced provider bridge support
-                $transport = \Glueful\Extensions\EmailNotification\TransportFactory::create($this->config);
+                return \Glueful\Extensions\EmailNotification\TransportFactory::createFailover($this->config);
             }
 
-            return new Mailer($transport);
+            // Use the default transport with enhanced provider bridge support
+            return \Glueful\Extensions\EmailNotification\TransportFactory::create($this->config);
         } catch (\Exception $e) {
             // Log the error for debugging
             $this->logger->error('Failed to create email transport: ' . $e->getMessage(), [
@@ -260,8 +299,7 @@ class EmailChannel implements NotificationChannel
             ]);
 
             // Fallback to null transport for development
-            $transport = Transport::fromDsn('null://null');
-            return new Mailer($transport);
+            return Transport::fromDsn('null://null');
         }
     }
 

--- a/src/EmailNotificationServiceProvider.php
+++ b/src/EmailNotificationServiceProvider.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Glueful\Extensions\EmailNotification;
 
 use Glueful\Bootstrap\ApplicationContext;
-use Glueful\Notifications\Services\ChannelManager;
 
 /**
  * Email Notification Service Provider
@@ -24,7 +23,10 @@ class EmailNotificationServiceProvider extends \Glueful\Extensions\ServiceProvid
         if (self::$cachedVersion === null) {
             $path = __DIR__ . '/../composer.json';
             $composer = json_decode(file_get_contents($path), true);
-            self::$cachedVersion = $composer['version'] ?? '0.0.0';
+            // Canonical version lives under extra.glueful.version (this is a library package
+            // with no top-level "version" key); fall back to a top-level key then a sentinel.
+            self::$cachedVersion = $composer['extra']['glueful']['version']
+                ?? ($composer['version'] ?? '0.0.0');
         }
 
         return self::$cachedVersion;
@@ -90,6 +92,13 @@ class EmailNotificationServiceProvider extends \Glueful\Extensions\ServiceProvid
         $config = require __DIR__ . '/../config/emailnotification.php';
         $config['templates']['extension_variables']['extension_version'] = self::composerVersion();
         $this->mergeConfig('emailnotification', $config);
+
+        // Framework 1.51.0 moved notification retry config to the channel-agnostic
+        // `notifications.retry` key (formerly read from `emailnotification.retry`). Surface our
+        // retry tuning there so the core retry service/command picks it up unchanged.
+        if (isset($config['retry']) && is_array($config['retry'])) {
+            $this->mergeConfig('notifications', ['retry' => $config['retry']]);
+        }
     }
 
     /**
@@ -97,24 +106,12 @@ class EmailNotificationServiceProvider extends \Glueful\Extensions\ServiceProvid
      */
     public function boot(ApplicationContext $context): void
     {
-        // Register the email channel with the notification system
-        if ($this->app->has(ChannelManager::class)) {
-            $provider = $this->app->get(EmailNotificationProvider::class);
-            if (method_exists($provider, 'initialize')) {
-                $provider->initialize();
-            }
-
-            $channel = $this->app->get(EmailChannel::class);
-            $this->app->get(ChannelManager::class)->registerChannel($channel);
-
-            // If a dispatcher is available via DI, also register provider hooks
-            if ($this->app->has(\Glueful\Notifications\Services\NotificationDispatcher::class)) {
-                $dispatcher = $this->app->get(\Glueful\Notifications\Services\NotificationDispatcher::class);
-                if (method_exists($dispatcher, 'registerExtension')) {
-                    $dispatcher->registerExtension($provider);
-                }
-            }
-        }
+        // Register the email channel and its before/after-send hooks through the framework's
+        // extension helpers (1.51.0+). These resolve the shared container ChannelManager /
+        // NotificationDispatcher and no-op if the notification subsystem isn't present — this is
+        // now the only wiring path (the framework no longer hardcodes this provider).
+        $this->registerNotificationChannel($this->app->get(EmailChannel::class));
+        $this->registerNotificationExtension($this->app->get(EmailNotificationProvider::class));
 
         // Register extension metadata for CLI and diagnostics
         try {


### PR DESCRIPTION
- EmailChannel implements RichNotificationChannel (structured NotificationResult: provider message id, latency, no_recipient/transport_exception error codes); send(): bool now delegates to sendNotification().
- boot() wires via registerNotificationChannel()/registerNotificationExtension() (the framework no longer hardcodes this provider).
- register() merges retry config under channel-agnostic notifications.retry.
- composerVersion() reads extra.glueful.version; bump framework to ^1.51.0, version 1.8.0.