### PR TITLE
Implement manifest descriptor and adopt effect verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [1.13.0] - 2026-08-17
+
 ### Added
 - Declares the Glueful schema manifest (migration descriptors, requires.extensions, structural
   verifier); requires framework >=1.79.0 for schema-on-enable participation. Migrations are now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [Unreleased]
+
+### Added
+- Declares the Glueful schema manifest (migration descriptors, requires.extensions, structural
+  verifier); requires framework >=1.79.0 for schema-on-enable participation. Migrations are now
+  registered by the manifest, not by provider boot.
+
 ## [1.12.0] - 2026-07-05
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
             "name": "EmailNotification",
             "displayName": "Email Notification",
             "description": "Provides email notification capabilities using Symfony Mailer",
-            "version": "1.12.0",
+            "version": "1.13.0",
             "icon": "assets/icon.png",
             "galleryBanner": {
                 "color": "#3064D0",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "symfony/mime": "^6.3 || ^7.0"
     },
     "require-dev": {
-        "glueful/framework": "^1.56.0",
+        "glueful/framework": "^1.79",
         "phpunit/phpunit": "^10.5",
         "squizlabs/php_codesniffer": "^3.6",
         "phpstan/phpstan": "^1.0"
@@ -68,9 +68,18 @@
             "publisher": "glueful-team",
             "provider": "Glueful\\Extensions\\EmailNotification\\EmailNotificationServiceProvider",
             "requires": {
-                "glueful": ">=1.56.0",
+                "glueful": ">=1.79.0",
                 "extensions": []
-            }
+            },
+            "migrations": [
+                {
+                    "id": "default",
+                    "path": "migrations",
+                    "priority": "default",
+                    "mode": "on_enable",
+                    "verifier": "Glueful\\Extensions\\EmailNotification\\Schema\\EmailNotificationSchemaVerifier"
+                }
+            ]
         }
     },
     "suggest": {

--- a/src/EmailNotificationServiceProvider.php
+++ b/src/EmailNotificationServiceProvider.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Glueful\Extensions\EmailNotification;
 
 use Glueful\Bootstrap\ApplicationContext;
-use Glueful\Database\Migrations\MigrationPriority;
 use Glueful\Extensions\Contracts\Email\EmailTemplateRegistry;
 use Glueful\Extensions\EmailNotification\Http\RequireEmailPermission;
 use Glueful\Extensions\EmailNotification\Http\SettingsController;
@@ -172,7 +171,7 @@ class EmailNotificationServiceProvider extends \Glueful\Extensions\ServiceProvid
      */
     public function boot(ApplicationContext $context): void
     {
-        $this->loadMigrationsFrom(__DIR__ . '/../migrations', MigrationPriority::DEFAULT, 'glueful/email-notification');
+        // Migrations are declared by the composer manifest (extra.glueful.migrations).
         $this->loadRoutesFrom(__DIR__ . '/../routes.php');
 
         if ($this->app->has(EmailTemplateRegistry::class)) {

--- a/src/Schema/EmailNotificationSchemaVerifier.php
+++ b/src/Schema/EmailNotificationSchemaVerifier.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Extensions\EmailNotification\Schema;
+
+use Glueful\Database\Connection;
+use Glueful\Extensions\Schema\StructuralVerifierInterface;
+
+/**
+ * Structural verifier for glueful/email-notification (schema policy spec B7): each create migration proves
+ * every table it creates with its load-bearing columns. Unknown basenames are never adoptable.
+ */
+final class EmailNotificationSchemaVerifier implements StructuralVerifierInterface
+{
+    public function source(): string
+    {
+        return 'glueful/email-notification';
+    }
+
+    /** @return list<string> */
+    public function migrationBasenames(): array
+    {
+        return [
+            '001_CreateEmailTemplatesTable.php',
+            '002_CreateEmailSettingsTable.php',
+        ];
+    }
+
+    public function verify(Connection $db, string $migrationBasename): bool
+    {
+        return match ($migrationBasename) {
+            '001_CreateEmailTemplatesTable.php' => $this->tablesWithColumns($db, [
+                'email_templates' => ['uuid', 'template_key'],
+            ]),
+            '002_CreateEmailSettingsTable.php' => $this->tablesWithColumns($db, [
+                'email_settings' => ['setting_key'],
+            ]),
+            default => false,
+        };
+    }
+
+    /** @param array<string, list<string>> $expectations */
+    private function tablesWithColumns(Connection $db, array $expectations): bool
+    {
+        $schema = $db->getSchemaBuilder();
+        foreach ($expectations as $table => $columns) {
+            if (!$schema->hasTable($table)) {
+                return false;
+            }
+            foreach ($columns as $column) {
+                if (!$schema->hasColumn($table, $column)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/tests/Integration/Schema/SchemaVerifierBehaviorTest.php
+++ b/tests/Integration/Schema/SchemaVerifierBehaviorTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Extensions\EmailNotification\Tests\Integration\Schema;
+
+use Glueful\Database\Connection;
+use Glueful\Database\Migrations\MigrationManager;
+use Glueful\Extensions\EmailNotification\Schema\EmailNotificationSchemaVerifier;
+use Glueful\Services\FileFinder;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The adoption contract (schema policy spec B7), proven over the whole chain: for every shipped
+ * migration, the verifier is FALSE on the sequential predecessor fixture (all earlier
+ * migrations applied, this one not) and TRUE after this one applies. This package folds no later
+ * effect into an earlier create, so the sequential chain is a valid incomplete-predecessor
+ * fixture for every basename.
+ */
+final class SchemaVerifierBehaviorTest extends TestCase
+{
+    private Connection $connection;
+    private MigrationManager $manager;
+    private EmailNotificationSchemaVerifier $verifier;
+    private string $dbPath;
+
+    protected function setUp(): void
+    {
+        $this->dbPath = sys_get_temp_dir() . '/email-notification-verify-' . uniqid('', true) . '.sqlite';
+        $this->connection = new Connection([
+            'engine' => 'sqlite',
+            'sqlite' => ['primary' => $this->dbPath],
+            'pooling' => ['enabled' => false],
+        ]);
+        $this->manager = new MigrationManager(
+            dirname(__DIR__, 3) . '/migrations',
+            new FileFinder(),
+            null,
+            $this->connection
+        );
+        $this->verifier = new EmailNotificationSchemaVerifier();
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->dbPath);
+    }
+
+    public function testEveryMigrationProofFlipsExactlyWithItsOwnMigration(): void
+    {
+        foreach ($this->verifier->migrationBasenames() as $basename) {
+            self::assertFalse(
+                $this->verifier->verify($this->connection, $basename),
+                "{$basename}: proof must be FALSE on its incomplete predecessor fixture"
+            );
+            $result = $this->manager->migrate(dirname(__DIR__, 3) . '/migrations/' . $basename);
+            self::assertSame([], $result['failed'], "fixture migration {$basename} must apply");
+            self::assertTrue(
+                $this->verifier->verify($this->connection, $basename),
+                "{$basename}: proof must be TRUE once its migration ran"
+            );
+        }
+    }
+
+    public function testUnknownBasenameIsNeverAdoptable(): void
+    {
+        self::assertFalse($this->verifier->verify($this->connection, '999_Unknown.php'));
+    }
+}

--- a/tests/Unit/Schema/SchemaManifestTest.php
+++ b/tests/Unit/Schema/SchemaManifestTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Extensions\EmailNotification\Tests\Unit\Schema;
+
+use Glueful\Extensions\EmailNotification\Schema\EmailNotificationSchemaVerifier;
+use PHPUnit\Framework\TestCase;
+
+final class SchemaManifestTest extends TestCase
+{
+    /** @return array<string, mixed> */
+    private function manifest(): array
+    {
+        $composer = json_decode((string) file_get_contents(dirname(__DIR__, 3) . '/composer.json'), true);
+        return $composer['extra']['glueful'];
+    }
+
+    public function testDeclaresExactlyOneDefaultDependentOnEnableDescriptor(): void
+    {
+        $migrations = $this->manifest()['migrations'];
+        self::assertCount(1, $migrations);
+        self::assertSame('default', $migrations[0]['id']);
+        self::assertSame('migrations', $migrations[0]['path']);
+        self::assertSame('default', $migrations[0]['priority']);
+        self::assertSame('on_enable', $migrations[0]['mode']);
+        self::assertSame('>=1.79.0', $this->manifest()['requires']['glueful']);
+        self::assertSame([], $this->manifest()['requires']['extensions']);
+    }
+
+    public function testVerifierClassConformsToTheManifestContract(): void
+    {
+        $class = $this->manifest()['migrations'][0]['verifier'];
+        self::assertTrue(class_exists($class));
+        self::assertTrue(is_subclass_of($class, \Glueful\Extensions\Schema\StructuralVerifierInterface::class));
+        $constructor = (new \ReflectionClass($class))->getConstructor();
+        self::assertTrue($constructor === null || $constructor->getNumberOfRequiredParameters() === 0);
+        self::assertSame('glueful/email-notification', (new $class())->source());
+    }
+
+    public function testVerifierCoversEveryRecursivelyDiscoveredMigration(): void
+    {
+        $mapped = (new EmailNotificationSchemaVerifier())->migrationBasenames();
+        $root = dirname(__DIR__, 3) . '/migrations';
+        $it = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($root, \FilesystemIterator::SKIP_DOTS)
+        );
+        $shipped = [];
+        foreach ($it as $file) {
+            if ($file->isFile() && $file->getExtension() === 'php') {
+                $shipped[] = $file->getBasename();
+            }
+        }
+        sort($shipped);
+        sort($mapped);
+        self::assertSame($shipped, $mapped, 'every migration file needs a verifier proof');
+    }
+
+    public function testResolvesWhenEnabledAloneAtItsDeclaredFloor(): void
+    {
+        $g = $this->manifest();
+        $candidates = ['glueful/email-notification' => new \Glueful\Extensions\ExtensionCandidate(
+            name: 'glueful/email-notification',
+            provider: $g['provider'],
+            requiresGlueful: $g['requires']['glueful'],
+            requiresExtensions: $g['requires']['extensions'],
+        )];
+        $result = (new \Glueful\Extensions\ExtensionResolver())
+            ->resolve($candidates, [$g['provider']], '1.79.0');
+        self::assertSame([], $result->errors, 'email-notification must resolve enabled-alone');
+    }
+
+    public function testProviderNoLongerRegistersTheManifestOwnedPath(): void
+    {
+        $provider = $this->manifest()['provider'];
+        $file = (new \ReflectionClass($provider))->getFileName();
+        self::assertIsString($file);
+        self::assertStringNotContainsString('loadMigrationsFrom(', (string) file_get_contents($file));
+    }
+}


### PR DESCRIPTION
- Declares the Glueful schema manifest (migration descriptors, requires.extensions, structural
  verifier); requires framework >=1.79.0 for schema-on-enable participation. Migrations are now
  registered by the manifest, not by provider boot.